### PR TITLE
Prettier

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,11 +10,11 @@ Ideally, the Save component should be derived from the View implementation, and 
 
 Blocks are structured using this folders/files:
 
-- `edit`: User code exclusive to the `Edit` component.
-- `view`: User code exclusive to the `View` component. It's also used as the `Save` component.
-- `shared`: User code shared between `Edit` and `View` components.
-- `gutenberg-packages`: Framework code that should be absorbed by Gutenberg packages.
-- `webpack`: Bundling configuration that should be absorbed by `@wordpress/scripts` (doesn't exist yet).
+-   `edit`: User code exclusive to the `Edit` component.
+-   `view`: User code exclusive to the `View` component. It's also used as the `Save` component.
+-   `shared`: User code shared between `Edit` and `View` components.
+-   `gutenberg-packages`: Framework code that should be absorbed by Gutenberg packages.
+-   `webpack`: Bundling configuration that should be absorbed by `@wordpress/scripts` (doesn't exist yet).
 
 ## Tracking issue and current status
 

--- a/jest.babel.config.js
+++ b/jest.babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	presets: [ [ '@babel/preset-env', { targets: { node: 'current' } } ] ],
+	presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	transform: {
-		'^.+\\.jsx?$': [ 'babel-jest', { configFile: './jest.babel.config.js' } ],
+		'^.+\\.jsx?$': ['babel-jest', { configFile: './jest.babel.config.js' }],
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4199,6 +4199,12 @@
 						}
 					}
 				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+					"dev": true
+				},
 				"string-width": {
 					"version": "4.2.3",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -13107,9 +13113,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+			"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,17 @@
 		"start": "wp-scripts start",
 		"wp-env": "wp-env"
 	},
+	"prettier": {
+		"useTabs": true,
+		"tabWidth": 4,
+		"printWidth": 80,
+		"singleQuote": true,
+		"trailingComma": "es5",
+		"bracketSameLine": false,
+		"bracketSpacing": true,
+		"semi": true,
+		"arrowParens": "always"
+	},
 	"devDependencies": {
 		"@babel/core": "^7.17.10",
 		"@babel/preset-env": "^7.17.10",
@@ -24,6 +35,7 @@
 		"@wordpress/env": "^4.4.0",
 		"@wordpress/scripts": "^22.3.0",
 		"babel-jest": "^28.1.0",
-		"jest": "^28.1.0"
+		"jest": "^28.1.0",
+		"prettier": "^2.7.1"
 	}
 }

--- a/src/blocks/block-hydration-experiments-child/edit.js
+++ b/src/blocks/block-hydration-experiments-child/edit.js
@@ -5,7 +5,7 @@
 import '@wordpress/block-editor';
 import { useBlockProps } from '@wordpress/block-editor';
 
-const Edit = ( { context } ) => {
+const Edit = ({ context }) => {
 	const blockProps = useBlockProps();
 
 	return (

--- a/src/blocks/block-hydration-experiments-child/frontend.js
+++ b/src/blocks/block-hydration-experiments-child/frontend.js
@@ -2,9 +2,9 @@ import CounterContext from '../../context/counter';
 import ThemeContext from '../../context/theme';
 import { useContext } from '../../gutenberg-packages/wordpress-element';
 
-const Frontend = ( { blockProps, context } ) => {
-	const theme = useContext( ThemeContext );
-	const counter = useContext( CounterContext );
+const Frontend = ({ blockProps, context }) => {
+	const theme = useContext(ThemeContext);
+	const counter = useContext(CounterContext);
 
 	return (
 		<div {...blockProps}>

--- a/src/blocks/block-hydration-experiments-child/index.js
+++ b/src/blocks/block-hydration-experiments-child/index.js
@@ -3,8 +3,8 @@ import Edit from './edit';
 import Frontend from './frontend';
 import './style.scss';
 
-registerBlockType( 'bhe/block-hydration-experiments-child', {
+registerBlockType('bhe/block-hydration-experiments-child', {
 	edit: Edit,
 	// The Save component is derived from the Frontend component.
 	frontend: Frontend,
-} );
+});

--- a/src/blocks/block-hydration-experiments-child/style.scss
+++ b/src/blocks/block-hydration-experiments-child/style.scss
@@ -1,9 +1,9 @@
 .wp-block-bhe-block-hydration-experiments-child {
-  padding: 15px 10px 15px 50px;
-  background-color: rgb(238, 237, 237);
+	padding: 15px 10px 15px 50px;
+	background-color: rgb(238, 237, 237);
 }
 
 gutenberg-block,
 gutenberg-inner-blocks {
-  display: contents;
+	display: contents;
 }

--- a/src/blocks/block-hydration-experiments-child/view.js
+++ b/src/blocks/block-hydration-experiments-child/view.js
@@ -3,6 +3,6 @@ import ThemeContext from '../../context/theme';
 import { registerBlockType } from '../../gutenberg-packages/frontend';
 import Frontend from './frontend';
 
-registerBlockType( 'bhe/block-hydration-experiments-child', Frontend, {
-	usesContext: [ ThemeContext, CounterContext ],
-} );
+registerBlockType('bhe/block-hydration-experiments-child', Frontend, {
+	usesContext: [ThemeContext, CounterContext],
+});

--- a/src/blocks/block-hydration-experiments-parent/edit.js
+++ b/src/blocks/block-hydration-experiments-parent/edit.js
@@ -8,20 +8,21 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import Button from './shared/button';
 import Title from './shared/title';
 
-export default function Edit(
-	{ attributes: { counter, message }, setAttributes },
-) {
+export default function Edit({
+	attributes: { counter, message },
+	setAttributes,
+}) {
 	const blockProps = useBlockProps();
 	return (
 		<>
 			<div {...blockProps}>
 				<Title
 					value={message}
-					onChange={( val ) => setAttributes( { message: val } )}
-					placeholder='Enter the Title'
+					onChange={(val) => setAttributes({ message: val })}
+					placeholder="Enter the Title"
 				/>
 				<Button />
-				<button onClick={() => setAttributes( { counter: counter + 1 } )}>
+				<button onClick={() => setAttributes({ counter: counter + 1 })}>
 					{counter}
 				</button>
 				<InnerBlocks />

--- a/src/blocks/block-hydration-experiments-parent/frontend/index.js
+++ b/src/blocks/block-hydration-experiments-parent/frontend/index.js
@@ -4,18 +4,22 @@ import { useState } from '../../../gutenberg-packages/wordpress-element';
 import Button from '../shared/button';
 import Title from '../shared/title';
 
-const Frontend = (
-	{ blockProps, attributes: { counter: initialCounter, message }, children },
-) => {
-	const [ show, setShow ] = useState( true );
-	const [ counter, setCounter ] = useState( initialCounter );
+const Frontend = ({
+	blockProps,
+	attributes: { counter: initialCounter, message },
+	children,
+}) => {
+	const [show, setShow] = useState(true);
+	const [counter, setCounter] = useState(initialCounter);
 	return (
 		<Counter.Provider value={counter}>
-			<Theme.Provider value='cool theme'>
+			<Theme.Provider value="cool theme">
 				<div {...blockProps}>
 					<Title message={message} />
-					<Button handler={() => setShow( !show )} />
-					<button onClick={() => setCounter( counter + 1 )}>{counter}</button>
+					<Button handler={() => setShow(!show)} />
+					<button onClick={() => setCounter(counter + 1)}>
+						{counter}
+					</button>
 					{show && children}
 				</div>
 			</Theme.Provider>

--- a/src/blocks/block-hydration-experiments-parent/index.js
+++ b/src/blocks/block-hydration-experiments-parent/index.js
@@ -3,8 +3,8 @@ import Edit from './edit';
 import Frontend from './frontend';
 import './style.scss';
 
-registerBlockType( 'bhe/block-hydration-experiments-parent', {
+registerBlockType('bhe/block-hydration-experiments-parent', {
 	edit: Edit,
 	// The Save component is derived from the Frontend component.
 	frontend: Frontend,
-} );
+});

--- a/src/blocks/block-hydration-experiments-parent/shared/button.js
+++ b/src/blocks/block-hydration-experiments-parent/shared/button.js
@@ -1,4 +1,4 @@
-const Button = ( { handler } ) => {
+const Button = ({ handler }) => {
 	return <button onClick={handler}>Show</button>;
 };
 

--- a/src/blocks/block-hydration-experiments-parent/shared/title.js
+++ b/src/blocks/block-hydration-experiments-parent/shared/title.js
@@ -1,7 +1,9 @@
 import { RichText } from '../../../gutenberg-packages/wordpress-blockeditor';
 
-const Title = ( { message, ...props } ) => (
-	<RichText tagName='h2' className='title' {...props}>{message}</RichText>
+const Title = ({ message, ...props }) => (
+	<RichText tagName="h2" className="title" {...props}>
+		{message}
+	</RichText>
 );
 
 export default Title;

--- a/src/blocks/block-hydration-experiments-parent/style.scss
+++ b/src/blocks/block-hydration-experiments-parent/style.scss
@@ -1,9 +1,9 @@
 .wp-block-bhe-block-hydration-experiments-parent {
-  padding: 15px 10px 15px 50px;
-  background-color: rgb(238, 237, 237);
+	padding: 15px 10px 15px 50px;
+	background-color: rgb(238, 237, 237);
 }
 
 gutenberg-block,
 gutenberg-inner-blocks {
-  display: contents;
+	display: contents;
 }

--- a/src/blocks/block-hydration-experiments-parent/view.js
+++ b/src/blocks/block-hydration-experiments-parent/view.js
@@ -3,6 +3,6 @@ import ThemeContext from '../../context/theme';
 import { registerBlockType } from '../../gutenberg-packages/frontend';
 import Frontend from './frontend';
 
-registerBlockType( 'bhe/block-hydration-experiments-parent', Frontend, {
-	providesContext: [ ThemeContext, CounterContext ],
-} );
+registerBlockType('bhe/block-hydration-experiments-parent', Frontend, {
+	providesContext: [ThemeContext, CounterContext],
+});

--- a/src/context/counter.js
+++ b/src/context/counter.js
@@ -1,7 +1,7 @@
 import { createContext } from '@wordpress/element';
 
-if ( typeof window.reactContext === 'undefined' ) {
-	window.reactContext = createContext( null );
+if (typeof window.reactContext === 'undefined') {
+	window.reactContext = createContext(null);
 }
 window.reactContext.displayName = 'CounterContext';
 export default window.reactContext;

--- a/src/context/theme.js
+++ b/src/context/theme.js
@@ -1,7 +1,7 @@
 import { createContext } from '@wordpress/element';
 
-if ( typeof window.themeReactContext === 'undefined' ) {
-	window.themeReactContext = createContext( null );
+if (typeof window.themeReactContext === 'undefined') {
+	window.themeReactContext = createContext(null);
 }
 window.themeReactContext.displayName = 'ThemeContext';
 export default window.themeReactContext;

--- a/src/gutenberg-packages/frontend.js
+++ b/src/gutenberg-packages/frontend.js
@@ -2,13 +2,13 @@ import { Consumer, createProvider } from './react-context';
 import { createGlobal, matcherFromSource } from './utils';
 import { EnvContext, hydrate } from './wordpress-element';
 
-const blockTypes = createGlobal( 'gutenbergBlockTypes', new Map() );
+const blockTypes = createGlobal('gutenbergBlockTypes', new Map());
 
-export const registerBlockType = ( name, Component, options ) => {
-	blockTypes.set( name, { Component, options } );
+export const registerBlockType = (name, Component, options) => {
+	blockTypes.set(name, { Component, options });
 };
 
-const Children = ( { value } ) => (
+const Children = ({ value }) => (
 	<gutenberg-inner-blocks
 		suppressHydrationWarning={true}
 		dangerouslySetInnerHTML={{ __html: value }}
@@ -16,120 +16,123 @@ const Children = ( { value } ) => (
 );
 Children.shouldComponentUpdate = () => false;
 
-const Wrappers = ( { wrappers, children } ) => {
+const Wrappers = ({ wrappers, children }) => {
 	let result = children;
-	wrappers.forEach( ( wrapper ) => {
-		result = wrapper( { children: result } );
-	} );
+	wrappers.forEach((wrapper) => {
+		result = wrapper({ children: result });
+	});
 	return result;
 };
 
 class GutenbergBlock extends HTMLElement {
 	connectedCallback() {
-		setTimeout( () => {
+		setTimeout(() => {
 			const blockContext = {};
 			const Providers = [];
 
 			// Get the block attributes.
 			const attributes = JSON.parse(
-				this.getAttribute( 'data-gutenberg-attributes' ),
+				this.getAttribute('data-gutenberg-attributes')
 			);
 
 			// Add the sourced attributes to the attributes object.
 			const sourcedAttributes = JSON.parse(
-				this.getAttribute( 'data-gutenberg-sourced-attributes' ),
+				this.getAttribute('data-gutenberg-sourced-attributes')
 			);
-			for ( const attr in sourcedAttributes ) {
-				attributes[attr] = matcherFromSource( sourcedAttributes[attr] )( this );
+			for (const attr in sourcedAttributes) {
+				attributes[attr] = matcherFromSource(sourcedAttributes[attr])(
+					this
+				);
 			}
 
 			// Get the Block Context from their parents.
 			const usesBlockContext = JSON.parse(
-				this.getAttribute( 'data-gutenberg-uses-block-context' ),
+				this.getAttribute('data-gutenberg-uses-block-context')
 			);
-			if ( usesBlockContext ) {
-				const event = new CustomEvent( 'gutenberg-block-context', {
+			if (usesBlockContext) {
+				const event = new CustomEvent('gutenberg-block-context', {
 					detail: { context: {} },
 					bubbles: true,
 					cancelable: true,
-				} );
-				this.dispatchEvent( event );
+				});
+				this.dispatchEvent(event);
 
 				// Select only the parts of the context that the block declared in the
 				// `usesContext` of its block.json.
-				usesBlockContext.forEach(key =>
-					blockContext[key] = event.detail.context[key]
+				usesBlockContext.forEach(
+					(key) => (blockContext[key] = event.detail.context[key])
 				);
 			}
 
 			// Prepare to share the Block Context with their children.
 			const providesBlockContext = JSON.parse(
-				this.getAttribute( 'data-gutenberg-provides-block-context' ),
+				this.getAttribute('data-gutenberg-provides-block-context')
 			);
-			if ( providesBlockContext ) {
-				this.addEventListener( 'gutenberg-block-context', ( event ) => {
+			if (providesBlockContext) {
+				this.addEventListener('gutenberg-block-context', (event) => {
 					// Select only the parts of the context that the block declared in
 					// the `providesContext` of its block.json.
-					Object.entries( providesBlockContext ).forEach(
-						( [ key, attribute ] ) => {
-							if ( !event.detail.context[key] ) {
-								event.detail.context[key] = attributes[attribute];
+					Object.entries(providesBlockContext).forEach(
+						([key, attribute]) => {
+							if (!event.detail.context[key]) {
+								event.detail.context[key] =
+									attributes[attribute];
 							}
-						},
+						}
 					);
-				} );
+				});
 			}
 
 			// Get the block type, block props, inner blocks, frontend component and
 			// options.
-			const blockType = this.getAttribute( 'data-gutenberg-block-type' );
+			const blockType = this.getAttribute('data-gutenberg-block-type');
 			const blockProps = {
 				className: this.children[0].className,
 				style: this.children[0].style,
 			};
-			const innerBlocks = this.querySelector( 'gutenberg-inner-blocks' );
-			const { Component, options } = blockTypes.get( blockType );
+			const innerBlocks = this.querySelector('gutenberg-inner-blocks');
+			const { Component, options } = blockTypes.get(blockType);
 
 			// Get the React Context from their parents.
-			options?.usesContext?.forEach( ( context ) => {
-				const event = new CustomEvent( 'gutenberg-react-context', {
+			options?.usesContext?.forEach((context) => {
+				const event = new CustomEvent('gutenberg-react-context', {
 					detail: { context },
 					bubbles: true,
 					cancelable: true,
-				} );
-				this.dispatchEvent( event );
-				Providers.push( event.detail.Provider );
-			} );
+				});
+				this.dispatchEvent(event);
+				Providers.push(event.detail.Provider);
+			});
 
 			// Prepare to share the React Context with their children.
-			if ( options?.providesContext?.length > 0 ) {
-				this.addEventListener( 'gutenberg-react-context', ( event ) => {
-					for ( const context of options.providesContext ) {
+			if (options?.providesContext?.length > 0) {
+				this.addEventListener('gutenberg-react-context', (event) => {
+					for (const context of options.providesContext) {
 						// We compare the provided context with the received context.
-						if ( event.detail.context === context ) {
+						if (event.detail.context === context) {
 							// If there's a match, we stop propagation.
 							event.stopPropagation();
 
 							// We return a Provider that is subscribed to the parent Provider.
-							event.detail.Provider = createProvider( {
+							event.detail.Provider = createProvider({
 								element: this,
 								context,
-							} );
+							});
 
 							// We can stop the iteration.
 							break;
 						}
 					}
-				} );
+				});
 			}
 
 			// Get the hydration technique.
-			const technique = this.getAttribute( 'data-gutenberg-hydrate' );
-			const media = this.getAttribute( 'data-gutenberg-media' );
+			const technique = this.getAttribute('data-gutenberg-hydrate');
+			const media = this.getAttribute('data-gutenberg-media');
 			const hydrationOptions = { technique, media };
 
 			hydrate(
-				<EnvContext.Provider value='frontend'>
+				<EnvContext.Provider value="frontend">
 					{/* Wrap the component with all the React Providers */}
 					<Wrappers wrappers={Providers}>
 						<Component
@@ -138,8 +141,12 @@ class GutenbergBlock extends HTMLElement {
 							context={blockContext}
 						>
 							{/* Update the value each time one of the React Contexts changes */}
-							{options?.providesContext?.map(( context, index ) => (
-								<Consumer key={index} element={this} context={context} />
+							{options?.providesContext?.map((context, index) => (
+								<Consumer
+									key={index}
+									element={this}
+									context={context}
+								/>
 							))}
 
 							{/* Render the inner blocks */}
@@ -153,19 +160,19 @@ class GutenbergBlock extends HTMLElement {
 					</Wrappers>
 
 					<template
-						className='gutenberg-inner-blocks'
+						className="gutenberg-inner-blocks"
 						suppressHydrationWarning={true}
 					/>
 				</EnvContext.Provider>,
 				this,
-				hydrationOptions,
+				hydrationOptions
 			);
-		} );
+		});
 	}
 }
 
 // We need to ensure that the component registration code is only run once
 // because it throws if you try to register an element with the same name twice.
-if ( customElements.get( 'gutenberg-interactive-block' ) === undefined ) {
-	customElements.define( 'gutenberg-interactive-block', GutenbergBlock );
+if (customElements.get('gutenberg-interactive-block') === undefined) {
+	customElements.define('gutenberg-interactive-block', GutenbergBlock);
 }

--- a/src/gutenberg-packages/react-context.js
+++ b/src/gutenberg-packages/react-context.js
@@ -1,66 +1,67 @@
 import { createGlobal } from './utils';
 import { useEffect, useState } from './wordpress-element';
 
-const subscribers = createGlobal( 'reactContextSubscribers', new WeakMap() );
-const values = createGlobal( 'reactContextValues', new WeakMap() );
+const subscribers = createGlobal('reactContextSubscribers', new WeakMap());
+const values = createGlobal('reactContextValues', new WeakMap());
 
-const updateValue = ( { element, context, value } ) => {
-	if ( !values.has( element ) ) {
-		values.set( element, new WeakMap() );
+const updateValue = ({ element, context, value }) => {
+	if (!values.has(element)) {
+		values.set(element, new WeakMap());
 	}
-	values.get( element ).set( context, value );
+	values.get(element).set(context, value);
 };
 
-const getValue = ( { element, context } ) => {
-	if ( values.has( element ) ) {
-		return values.get( element ).get( context );
+const getValue = ({ element, context }) => {
+	if (values.has(element)) {
+		return values.get(element).get(context);
 	}
 };
 
-const subscribe = ( { element, context, callback } ) => {
-	if ( !subscribers.has( element ) ) {
-		subscribers.set( element, new WeakMap() );
+const subscribe = ({ element, context, callback }) => {
+	if (!subscribers.has(element)) {
+		subscribers.set(element, new WeakMap());
 	}
-	if ( !subscribers.get( element ).has( context ) ) {
-		subscribers.get( element ).set( context, new Set() );
+	if (!subscribers.get(element).has(context)) {
+		subscribers.get(element).set(context, new Set());
 	}
-	subscribers.get( element ).get( context ).add( callback );
+	subscribers.get(element).get(context).add(callback);
 };
 
-const unsubscribe = ( { element, context, callback } ) => {
-	subscribers.get( element ).get( context ).delete( callback );
+const unsubscribe = ({ element, context, callback }) => {
+	subscribers.get(element).get(context).delete(callback);
 };
 
-const updateProvider = ( { element, context, value } ) => {
-	updateValue( { element, context, value } );
+const updateProvider = ({ element, context, value }) => {
+	updateValue({ element, context, value });
 
-	if (subscribers.has( element ) && subscribers.get( element ).has( context )) {
+	if (subscribers.has(element) && subscribers.get(element).has(context)) {
 		// This setTimeout prevents a React warning about calling setState inside a
 		// render() function, which is misleading because the render() function
 		// belongs to a different React application. It may not happen in React 18.
-		setTimeout( () => {
+		setTimeout(() => {
 			subscribers
-				.get( element )
-				.get( context )
-				.forEach(callback => callback( value ));
-		} );
+				.get(element)
+				.get(context)
+				.forEach((callback) => callback(value));
+		});
 	}
 };
 
-export const createProvider = ( { element, context } ) =>
-	( { children } ) => {
-		const [ value, setValue ] = useState( getValue( { element, context } ) );
+export const createProvider =
+	({ element, context }) =>
+	({ children }) => {
+		const [value, setValue] = useState(getValue({ element, context }));
 
-		useEffect( () => {
-			subscribe( { element, context, callback: setValue } );
-			return () => unsubscribe( { element, context, callback: setValue } );
-		}, [] );
+		useEffect(() => {
+			subscribe({ element, context, callback: setValue });
+			return () => unsubscribe({ element, context, callback: setValue });
+		}, []);
 
 		return <context.Provider value={value}>{children}</context.Provider>;
 	};
 
-export const Consumer = ( { element, context } ) => (
+export const Consumer = ({ element, context }) => (
 	<context.Consumer>
-		{value => updateProvider( { element, context, value } )}
+		{(value) => updateProvider({ element, context, value })}
 	</context.Consumer>
 );

--- a/src/gutenberg-packages/utils.js
+++ b/src/gutenberg-packages/utils.js
@@ -1,19 +1,19 @@
 import { text } from 'hpq';
 
 // See https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/src/api/parser/get-block-attributes.js#L185
-export const matcherFromSource = ( sourceConfig ) => {
-	switch ( sourceConfig.source ) {
+export const matcherFromSource = (sourceConfig) => {
+	switch (sourceConfig.source) {
 		// TODO: Add cases for other source types.
 		case 'text':
-			return text( sourceConfig.selector );
+			return text(sourceConfig.selector);
 	}
 };
 
 // We have to do this because of the way we are currently bundling the code in
 // this repo, each block gets its own copy of this file, but this won't happen
 // if/when we do this in Gutenberg.
-export const createGlobal = ( name, initialValue ) => {
-	if ( typeof window[name] === 'undefined' ) {
+export const createGlobal = (name, initialValue) => {
+	if (typeof window[name] === 'undefined') {
 		window[name] = initialValue;
 	}
 	return window[name];

--- a/src/gutenberg-packages/wordpress-blockeditor.js
+++ b/src/gutenberg-packages/wordpress-blockeditor.js
@@ -1,14 +1,14 @@
 import '@wordpress/block-editor';
 import { useBlockEnvironment } from './wordpress-element';
 
-export const RichText = ( { tagName: Tag, children, ...props } ) => {
-	return useBlockEnvironment() === 'edit' ?
-		(
-			<window.wp.blockEditor.RichText
-				value={children}
-				tagName={Tag}
-				{...props}
-			/>
-		) :
-		<Tag {...props} dangerouslySetInnerHTML={{ __html: children }} />;
+export const RichText = ({ tagName: Tag, children, ...props }) => {
+	return useBlockEnvironment() === 'edit' ? (
+		<window.wp.blockEditor.RichText
+			value={children}
+			tagName={Tag}
+			{...props}
+		/>
+	) : (
+		<Tag {...props} dangerouslySetInnerHTML={{ __html: children }} />
+	);
 };

--- a/src/gutenberg-packages/wordpress-blocks.js
+++ b/src/gutenberg-packages/wordpress-blocks.js
@@ -1,25 +1,31 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { registerBlockType as gutenbergRegisterBlockType } from '@wordpress/blocks';
 
-const save = ( Comp ) =>
-	( { attributes } ) => {
+const save =
+	(Comp) =>
+	({ attributes }) => {
 		const blockProps = useBlockProps.save();
 		const innerBlocksProps = useInnerBlocksProps.save();
 
 		return (
 			<>
-				<Comp blockProps={blockProps} attributes={attributes} context={{}}>
+				<Comp
+					blockProps={blockProps}
+					attributes={attributes}
+					context={{}}
+				>
 					<gutenberg-inner-blocks {...innerBlocksProps} />
 				</Comp>
-				{
-					/* Render InnerBlocks inside a template, to avoid losing them
-            if Comp doesn't render them. */
-				}
-				<template class='gutenberg-inner-blocks' {...innerBlocksProps} />
+				{/* Render InnerBlocks inside a template, to avoid losing them
+            if Comp doesn't render them. */}
+				<template
+					class="gutenberg-inner-blocks"
+					{...innerBlocksProps}
+				/>
 			</>
 		);
 	};
 
-export const registerBlockType = ( name, { frontend, edit, ...rest } ) => {
-	gutenbergRegisterBlockType( name, { edit, save: save( frontend ), ...rest } );
+export const registerBlockType = (name, { frontend, edit, ...rest }) => {
+	gutenbergRegisterBlockType(name, { edit, save: save(frontend), ...rest });
 };

--- a/src/gutenberg-packages/wordpress-element.js
+++ b/src/gutenberg-packages/wordpress-element.js
@@ -6,7 +6,7 @@ import {
 } from '@wordpress/element';
 import { hydrate as ReactHydrate } from 'react-dom';
 
-export const EnvContext = createContext( null );
+export const EnvContext = createContext(null);
 
 /**
  * A React hook that returns the name of the environment.
@@ -19,8 +19,8 @@ export const EnvContext = createContext( null );
  */
 export const useBlockEnvironment = () => {
 	try {
-		const env = useReactContext( EnvContext );
-		if ( env === 'frontend' ) {
+		const env = useReactContext(EnvContext);
+		if (env === 'frontend') {
 			return 'frontend';
 		}
 		return 'edit';
@@ -31,32 +31,32 @@ export const useBlockEnvironment = () => {
 
 const noop = () => {};
 
-export const useState = ( init ) =>
-	useBlockEnvironment() !== 'save' ? useReactState( init ) : [ init, noop ];
+export const useState = (init) =>
+	useBlockEnvironment() !== 'save' ? useReactState(init) : [init, noop];
 
-export const useEffect = ( ...args ) =>
-	useBlockEnvironment() !== 'save' ? useReactEffect( ...args ) : noop;
+export const useEffect = (...args) =>
+	useBlockEnvironment() !== 'save' ? useReactEffect(...args) : noop;
 
-export const useContext = ( Context ) =>
-	useBlockEnvironment() !== 'save' ?
-		useReactContext( Context ) :
-		Context._currentValue;
+export const useContext = (Context) =>
+	useBlockEnvironment() !== 'save'
+		? useReactContext(Context)
+		: Context._currentValue;
 
-export const hydrate = ( element, container, hydrationOptions ) => {
+export const hydrate = (element, container, hydrationOptions) => {
 	const { technique, media } = hydrationOptions || {};
 
 	const cb = () => {
-		ReactHydrate( element, container );
+		ReactHydrate(element, container);
 	};
 
-	switch ( technique ) {
+	switch (technique) {
 		case 'media':
-			if ( media ) {
-				const mql = matchMedia( media );
-				if ( mql.matches ) {
+			if (media) {
+				const mql = matchMedia(media);
+				if (mql.matches) {
 					cb();
 				} else {
-					mql.addEventListener( 'change', cb, { once: true } );
+					mql.addEventListener('change', cb, { once: true });
 				}
 			}
 			break;
@@ -66,9 +66,9 @@ export const hydrate = ( element, container, hydrationOptions ) => {
 
 		case 'view':
 			try {
-				const io = new IntersectionObserver( ( entries ) => {
-					for ( const entry of entries ) {
-						if ( !entry.isIntersecting ) {
+				const io = new IntersectionObserver((entries) => {
+					for (const entry of entries) {
+						if (!entry.isIntersecting) {
 							continue;
 						}
 						// As soon as we hydrate, disconnect this IntersectionObserver.
@@ -76,8 +76,8 @@ export const hydrate = ( element, container, hydrationOptions ) => {
 						cb();
 						break; // Break loop on first match.
 					}
-				} );
-				io.observe( container.children[0] );
+				});
+				io.observe(container.children[0]);
 			} catch (e) {
 				cb();
 			}
@@ -86,10 +86,10 @@ export const hydrate = ( element, container, hydrationOptions ) => {
 		case 'idle':
 			// Safari does not support requestIdleCalback, we use a timeout instead.
 			// https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
-			if ( 'requestIdleCallback' in window ) {
-				window.requestIdleCallback( cb );
+			if ('requestIdleCallback' in window) {
+				window.requestIdleCallback(cb);
 			} else {
-				setTimeout( cb, 200 );
+				setTimeout(cb, 200);
 			}
 			break;
 


### PR DESCRIPTION
Add `prettier` with the settings from [Gutenberg](https://github.com/WordPress/gutenberg/blob/trunk/packages/prettier-config/lib/index.js).

This is regular `prettier`, not the `wp-prettier` fork, so no spacing now.

I'll add `prettier-php` in a future PR.