### PR TITLE
Unmount react component when `WpBlock` is disconnected

### DIFF
--- a/src/gutenberg-packages/frontend.js
+++ b/src/gutenberg-packages/frontend.js
@@ -1,6 +1,7 @@
 import { Consumer, createProvider } from './react-context';
 import { createGlobal, matcherFromSource } from './utils';
 import { EnvContext, hydrate } from './wordpress-element';
+import { unmountComponentAtNode } from 'react-dom';
 
 const blockTypes = createGlobal('wpBlockTypes', new Map());
 
@@ -178,6 +179,11 @@ class WpBlock extends HTMLElement {
 				);
 			}
 		});
+	}
+
+	disconnectedCallback() {
+		// Unmount the React component, running callbacks and cleaning up its state.
+		unmountComponentAtNode(this);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/block-hydration-experiments/issues/42.

The solution is straightforward. Inside the [`disconnectCallback()`](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks) defined in `WpBlock`, we run [`unmountComponentAtNode(this)`](https://reactjs.org/docs/react-dom.html#unmountcomponentatnode) to safely unmount the React tree within the `WpBlock` instance.

Here is a video where I show how it works: https://github.com/WordPress/block-hydration-experiments/issues/42#issuecomment-1203271407