### PR TITLE
Use block support flag for hydration opt-in

### DIFF
--- a/block-hydration-experiments.php
+++ b/block-hydration-experiments.php
@@ -25,22 +25,12 @@ add_action('init', 'block_hydration_experiments_init');
 
 function bhe_block_wrapper($block_content, $block, $instance)
 {
-	// We might want to use a flag from block.json as the criterion here.
-	if (
-		!in_array(
-			$block['blockName'],
-			[
-				'bhe/interactive-parent',
-				'bhe/interactive-child',
-				'bhe/non-interactive-parent',
-			],
-			true
-		)
-	) {
+	$block_type = $instance->block_type;
+
+	if ( ! block_has_support( $block_type, [ 'view' ] ) ) {
 		return $block_content;
 	}
 
-	$block_type = $instance->block_type;
 	$attr_definitions = $block_type->attributes;
 
 	$attributes = [];
@@ -63,13 +53,7 @@ function bhe_block_wrapper($block_content, $block, $instance)
 	}
 
 	// We might want to use a flag from block.json as the criterion here.
-	$hydration_technique = in_array(
-		$block['blockName'],
-		['bhe/interactive-parent', 'bhe/interactive-child'],
-		true
-	)
-		? 'idle'
-		: false;
+	$hydration_technique = $block_type->supports['view']['hydration'] ?? 'idle';
 
 	// The following is a bit hacky. If we stick with this technique, we might
 	// want to change apply_block_supports() to accepts a block as its argument.

--- a/src/blocks/interactive-child/block.json
+++ b/src/blocks/interactive-child/block.json
@@ -15,7 +15,8 @@
 		"typography": {
 			"fontSize": true
 		},
-		"html": true
+		"html": true,
+		"view": true
 	},
 	"textdomain": "block-hydration-experiments",
 	"editorScript": "file:./index.js",

--- a/src/blocks/interactive-parent/block.json
+++ b/src/blocks/interactive-parent/block.json
@@ -33,7 +33,8 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true
 		},
-		"html": true
+		"html": true,
+		"view": true
 	},
 	"providesContext": {
 		"bhe/interactive-title": "title"

--- a/src/blocks/non-interactive-parent/block.json
+++ b/src/blocks/non-interactive-parent/block.json
@@ -22,7 +22,10 @@
 		"color": {
 			"text": true
 		},
-		"html": true
+		"html": true,
+		"view": {
+			"hydration": false
+		}
 	},
 	"textdomain": "block-hydration-experiments",
 	"editorScript": "file:./index.js",


### PR DESCRIPTION
Change the hard-coded list of supported blocks in the `render_block` hook. 
Use a support flag, `view`, to enable frontend block hydration.

Also use an extend form of the flag to control the hydration technique setting. 

At this point this is just a quick step to allow adding new blocks, I imagine the final API might look different.
