### PR TITLE
Fix missing context error

### DIFF
--- a/src/gutenberg-packages/frontend.js
+++ b/src/gutenberg-packages/frontend.js
@@ -110,7 +110,9 @@ class WpBlock extends HTMLElement {
 						cancelable: true,
 					});
 					this.dispatchEvent(event);
-					Providers.push(event.detail.Provider);
+					if (typeof event.detail.Provider === 'function') {
+						Providers.push(event.detail.Provider);
+					}
 				});
 
 				// Share the React Context with their children.


### PR DESCRIPTION
Fix #46, according to [my comment](https://github.com/WordPress/block-hydration-experiments/issues/46#issuecomment-1208276498):

> I think it would make sense if "our" `useContext` was consistent with React's and -- in the absence of a Provider -- returned the default value used [when creating the context](https://github.com/WordPress/block-hydration-experiments/blob/564639c6c767eda8330be86d41eaca6b6534648e/src/context/counter.js#L4):
>
>> `const MyContext = React.createContext(defaultValue);`
>> [...]
>> The `defaultValue` argument is **only** used when a component does not have a matching Provider above it in the tree. This default value can be helpful for testing components in isolation without wrapping them. Note: passing `undefined` as a Provider value does not cause consuming components to use `defaultValue`.
>
> [(source)](https://reactjs.org/docs/context.html#reactcreatecontext)

### Testing instructions

- Verify that an Interactive Child block inside a Non-interactive Parent block works now:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/96308/183460314-247ec783-da95-45c0-aa87-69d589634818.png">


- Verify that the Interactive Child block falls back to the default context passed when creating the context by applying the following patch:

```diff
diff --git a/src/context/counter.js b/src/context/counter.js
index 6061f47..0fa0325 100644
--- a/src/context/counter.js
+++ b/src/context/counter.js
@@ -1,7 +1,7 @@
 import { createContext } from '@wordpress/element';
 
 if (typeof window.reactContext === 'undefined') {
-       window.reactContext = createContext(null);
+       window.reactContext = createContext(0);
 }
 window.reactContext.displayName = 'CounterContext';
 export default window.reactContext;
diff --git a/src/context/theme.js b/src/context/theme.js
index 8aefc8e..d63cc62 100644
--- a/src/context/theme.js
+++ b/src/context/theme.js
@@ -1,7 +1,7 @@
 import { createContext } from '@wordpress/element';
 
 if (typeof window.themeReactContext === 'undefined') {
-       window.themeReactContext = createContext(null);
+       window.themeReactContext = createContext('twentytwentytwo');
 }
 window.themeReactContext.displayName = 'ThemeContext';
 export default window.themeReactContext;
```

Result:

<img width="792" alt="image" src="https://user-images.githubusercontent.com/96308/183460485-febc8f8d-66e1-4446-9e52-efe87f77c9d7.png">

- Verify that the if there _is_ an intermediate layer with an Interactive Parent block, its context continues to be respected by the child block:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/96308/183460955-a65abaf1-1674-4d7b-aa83-49793a0dd5cb.png">
