### PR TITLE
Add missing `hpq` dependency in the package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2864,7 +2864,7 @@
 		"@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
 		"@types/keyv": {
@@ -4528,7 +4528,7 @@
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
 			"dev": true
 		},
 		"array-flatten": {
@@ -4559,7 +4559,7 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
 			"dev": true
 		},
 		"array.prototype.filter": {
@@ -4602,13 +4602,13 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
 			"dev": true
 		},
 		"ast-types-flow": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+			"integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
 			"dev": true
 		},
 		"astral-regex": {
@@ -4620,7 +4620,7 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
 		"autoprefixer": {
@@ -4998,7 +4998,7 @@
 		"batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+			"integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
 			"dev": true
 		},
 		"big.js": {
@@ -5104,7 +5104,7 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -5167,7 +5167,7 @@
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
 			"dev": true
 		},
 		"buffer-from": {
@@ -5179,7 +5179,7 @@
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
 			"dev": true
 		},
 		"cacheable-lookup": {
@@ -6243,7 +6243,7 @@
 				"array-union": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+					"integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
 					"dev": true,
 					"requires": {
 						"array-uniq": "^1.0.1"
@@ -8237,8 +8237,7 @@
 		"hpq": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
-			"integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA==",
-			"dev": true
+			"integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
 		},
 		"html-element-map": {
 			"version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
 		"babel-jest": "^28.1.0",
 		"jest": "^28.1.0",
 		"prettier": "^2.7.1"
+	},
+	"dependencies": {
+		"hpq": "^1.3.0"
 	}
 }


### PR DESCRIPTION
As the title says. 

We're using `hpq` in https://github.com/WordPress/block-hydration-experiments/blob/ee32b600a731eb9a40c350c85672a7245b31b033/src/gutenberg-packages/utils.js#L1-L2